### PR TITLE
feat(nepali-calendar): add slots and style prop for nepali-calender h…

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ const modelValue = ref('2055-02-20');
 
 ```vue
 <script setup>
-import { defineProps, ref } from 'vue';
+import { ref } from 'vue';
 import { useDate } from 'np-date-picker-vue-3';
 
 const props = defineProps({

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "nepali-date": "^0.1.3",
-        "vue": "^3.5.13"
+        "vue": "^3.5.25"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.3",
@@ -270,18 +270,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -312,12 +312,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.28.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -476,13 +476,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -1370,53 +1370,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.25.tgz",
+      "integrity": "sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/shared": "3.5.13",
+        "@babel/parser": "^7.28.5",
+        "@vue/shared": "3.5.25",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.0"
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
-      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.25.tgz",
+      "integrity": "sha512-4We0OAcMZsKgYoGlMjzYvaoErltdFI2/25wqanuTu+S4gismOTRTBPi4IASOjxWdzIwrYSjnqONfKvuqkXzE2Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-core": "3.5.25",
+        "@vue/shared": "3.5.25"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
-      "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz",
+      "integrity": "sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/compiler-core": "3.5.13",
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/compiler-ssr": "3.5.13",
-        "@vue/shared": "3.5.13",
+        "@babel/parser": "^7.28.5",
+        "@vue/compiler-core": "3.5.25",
+        "@vue/compiler-dom": "3.5.25",
+        "@vue/compiler-ssr": "3.5.25",
+        "@vue/shared": "3.5.25",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.11",
-        "postcss": "^8.4.48",
-        "source-map-js": "^1.2.0"
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
-      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.25.tgz",
+      "integrity": "sha512-ritPSKLBcParnsKYi+GNtbdbrIE1mtuFEJ4U1sWeuOMlIziK5GtOL85t5RhsNy4uWIXPgk+OUdpnXiTdzn8o3A==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-dom": "3.5.25",
+        "@vue/shared": "3.5.25"
       }
     },
     "node_modules/@vue/devtools-core": {
@@ -1483,53 +1483,53 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
-      "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.25.tgz",
+      "integrity": "sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.13"
+        "@vue/shared": "3.5.25"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
-      "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz",
+      "integrity": "sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/reactivity": "3.5.25",
+        "@vue/shared": "3.5.25"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
-      "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz",
+      "integrity": "sha512-a4WrkYFbb19i9pjkz38zJBg8wa/rboNERq3+hRRb0dHiJh13c+6kAbgqCPfMaJ2gg4weWD3APZswASOfmKwamA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.13",
-        "@vue/runtime-core": "3.5.13",
-        "@vue/shared": "3.5.13",
+        "@vue/reactivity": "3.5.25",
+        "@vue/runtime-core": "3.5.25",
+        "@vue/shared": "3.5.25",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
-      "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.25.tgz",
+      "integrity": "sha512-UJaXR54vMG61i8XNIzTSf2Q7MOqZHpp8+x3XLGtE3+fL+nQd+k7O5+X3D/uWrnQXOdMw5VPih+Uremcw+u1woQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-ssr": "3.5.25",
+        "@vue/shared": "3.5.25"
       },
       "peerDependencies": {
-        "vue": "3.5.13"
+        "vue": "3.5.25"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.25.tgz",
+      "integrity": "sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==",
       "license": "MIT"
     },
     "node_modules/birpc": {
@@ -1651,9 +1651,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2129,12 +2129,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mitt": {
@@ -2302,9 +2302,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2321,7 +2321,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2772,16 +2772,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
-      "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+      "version": "3.5.25",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
+      "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/compiler-sfc": "3.5.13",
-        "@vue/runtime-dom": "3.5.13",
-        "@vue/server-renderer": "3.5.13",
-        "@vue/shared": "3.5.13"
+        "@vue/compiler-dom": "3.5.25",
+        "@vue/compiler-sfc": "3.5.25",
+        "@vue/runtime-dom": "3.5.25",
+        "@vue/server-renderer": "3.5.25",
+        "@vue/shared": "3.5.25"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "nepali-date": "^0.1.3",
-    "vue": "^3.5.13"
+    "vue": "^3.5.25"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -74,16 +74,6 @@ const slottedDatePickerRef = ref(null);
         v-model="slottedDate"
         :calenderHeaderStyle="{ backgroundColor: '#b81c1d' }"
       >
-        <template #calendar-year>
-          <div class="slotted-calender-year">
-            Custom Year: {{ slottedDatePickerRef?.formattedYear }}
-          </div>
-        </template>
-        <template #calendar-date="{ formattedDate }">
-          <div class="slotted-calender-date">
-            formattedDate: {{ formattedDate }}
-          </div>
-        </template>
       </NepaliDatePicker>
     </div>
   </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from "vue";
+import { ref, useTemplateRef } from "vue";
 
 import NepaliDatePicker from "./components/NepaliDatePicker.vue";
 
@@ -11,8 +11,8 @@ const nepaliDate = ref("");
 const englishDate1 = ref("");
 const nepaliDate1 = ref("");
 const slottedDate = ref("");
-// Template ref to access the exposed composable state from NepaliDatePicker
-const slottedDatePickerRef = ref(null);
+
+const nepaliDatePicker = useTemplateRef("nepaliDatePickerRef");
 </script>
 
 <template>
@@ -70,11 +70,10 @@ const slottedDatePickerRef = ref(null);
     <div style="max-width: 200px">
       <label>Nepali date picker with slots</label>
       <NepaliDatePicker
-        ref="slottedDatePickerRef"
+        ref="nepaliDatePickerRef"
         v-model="slottedDate"
         :calenderHeaderStyle="{ backgroundColor: '#b81c1d' }"
-      >
-      </NepaliDatePicker>
+      />
     </div>
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,11 +5,17 @@ import NepaliDatePicker from "./components/NepaliDatePicker.vue";
 
 import Meeting from "./examples/Meeting.vue";
 import CustomDatePicker from "./examples/CustomDatePicker.vue";
+import useDate from "./composables/useDate";
 
 const englishDate = ref("");
 const nepaliDate = ref("");
 const englishDate1 = ref("");
 const nepaliDate1 = ref("");
+const slottedDate = ref("");
+
+const { formattedYear } = useDate({
+  modelValue: slottedDate.value,
+});
 </script>
 
 <template>
@@ -64,5 +70,30 @@ const nepaliDate1 = ref("");
         <div class="mt-4">{{ nepaliDate1 }}</div>
       </div>
     </div>
+    <div style="max-width: 200px">
+      <label>Nepali date picker with slots</label>
+      <NepaliDatePicker v-model="slottedDate" :calenderHeaderStyle="{ backgroundColor: '#b81c1d' }">
+        <template #calendar-year>
+          <div class="slotted-calender-year">
+            Custom Year: {{ formattedYear }}
+          </div>
+        </template>
+        <template #calendar-date="{ formattedDate }">
+          <div class="slotted-calender-date">
+            formattedDate: {{ formattedDate }}
+          </div>
+        </template>
+      </NepaliDatePicker>
+    </div>
   </div>
 </template>
+
+<style scoped>
+.slotted-calender-year {
+  color: #d5d5d5;
+}
+
+.slotted-calender-date {
+  color: #bcbcbc;
+}
+</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,8 @@ const nepaliDate = ref("");
 const englishDate1 = ref("");
 const nepaliDate1 = ref("");
 const slottedDate = ref("");
+// Template ref to access the exposed composable state from NepaliDatePicker
+const slottedDatePickerRef = ref(null);
 </script>
 
 <template>
@@ -68,12 +70,13 @@ const slottedDate = ref("");
     <div style="max-width: 200px">
       <label>Nepali date picker with slots</label>
       <NepaliDatePicker
+        ref="slottedDatePickerRef"
         v-model="slottedDate"
         :calenderHeaderStyle="{ backgroundColor: '#b81c1d' }"
       >
-        <template #calendar-year="{ formattedYear }">
+        <template #calendar-year>
           <div class="slotted-calender-year">
-            Custom Year: {{ formattedYear }}
+            Custom Year: {{ slottedDatePickerRef?.formattedYear }}
           </div>
         </template>
         <template #calendar-date="{ formattedDate }">

--- a/src/components/NepaliDatePicker.vue
+++ b/src/components/NepaliDatePicker.vue
@@ -16,9 +16,54 @@ const props = defineProps({
   monthSelect: { type: Boolean, default: true },
   classValue: { type: String, default: "" },
   placeholder: { type: String, default: "" },
-  calenderHeaderStyle: { type: Object, default: () => ({}) },
-  calenderYearStyle: { type: Object, default: () => ({}) },
-  calenderDateStyle: { type: Object, default: () => ({}) },
+  calendarHeaderStyle: { type: Object, default: () => ({}) },
+  calendarYearStyle: { type: Object, default: () => ({}) },
+  calendarDateStyle: { type: Object, default: () => ({}) },
+  calendarBodyStyle: { type: Object, default: () => ({}) },
+  calendarMonthStyle: { type: Object, default: () => ({}) },
+  monthSelectStyle: { type: Object, default: () => ({}) },
+  yearSelectStyle: {
+    type: Object,
+    default: () => ({
+      "margin-left": "5px",
+    }),
+  },
+  calendarWeekWrapperStyle: {
+    type: Object,
+    default: () => ({
+      padding: "3px",
+    }),
+  },
+  calendarWeeksStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+  calendarWeekDaysStyle: {
+    type: Object,
+    default: () => ({
+      "font-weight": "bold",
+    }),
+  },
+  calendarDaysWrapperStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+  calendarDaySpacerStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+  calendarDayStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+  datePickerWrapperStyle: {
+    type: Object,
+    default: () => ({}),
+  },
+  calendarFooterStyle: {
+    type: Object,
+    default: () => ({}),
+  },
 });
 
 const dateValue = defineModel({ default: "" });
@@ -90,7 +135,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="datepicker" @click.stop>
+  <div class="datepicker" @click.stop :style="datePickerWrapperStyle">
     <input
       type="text"
       v-model="dateValue"
@@ -100,102 +145,192 @@ defineExpose({
       :class="classValue"
     />
     <div v-if="visible" :class="['calendar', { show: visible }]">
-      <slot name="calender-header">
-        <div class="calendar__header" :style="calenderHeaderStyle">
+      <slot name="calendar-header">
+        <div class="calendar__header" :style="calendarHeaderStyle">
           <slot name="calendar-year" :formattedYear="formattedYear">
-            <div class="calendar__year" :style="calenderYearStyle">
+            <div class="calendar__year" :style="calendarYearStyle">
               {{ formattedYear }}
             </div>
           </slot>
           <slot name="calendar-date" :formattedDate="formattedDate">
-            <div class="calendar__date" :style="calenderDateStyle">
+            <div class="calendar__date" :style="calendarDateStyle">
               {{ formattedDate }}
             </div>
           </slot>
         </div>
       </slot>
-      <div class="calendar__body">
-        <!-- month -->
-        <div class="calendar__month">
-          <button class="calendar__month__prev" @click="prev">
-            <b>></b>
-          </button>
-          <span>{{ formattedYearOrMonth }} </span>
-          <select
-            @change="monthSelectChange"
-            v-model="monthValue"
-            size="mini"
-            v-if="monthSelect"
-            style=""
-          >
-            <option
-              style="text-align-last: center"
-              v-for="(month, index) in getMonthsList"
-              :key="month"
-              :label="month"
-              :value="index"
-            >
-              <!-- {{ month }} -->
-            </option>
-          </select>
-          <select
-            @change="yearSelectChange"
-            v-model="yearValue"
-            size="mini"
-            v-if="yearSelect"
-            style="margin-left: 5px"
-          >
-            <option
-              style="text-align-last: center"
-              v-for="i in numberOfYears"
-              :key="i"
-              :value="startingYear + (i - 1)"
-              :label="
-                formatNepali
-                  ? getNepaliDateWithYear(startingYear + (i - 1)).substr(0, 4)
-                  : startingYear + (i - 1)
-              "
-            ></option>
-          </select>
-          <button icon="el-icon-arrow-right" @click="next"><b>></b></button>
-        </div>
+      <slot
+        name="calendar-body"
+        :prev="prev"
+        :next="next"
+        :monthValue="monthValue"
+        :yearValue="yearValue"
+        :monthSelectChange="monthSelectChange"
+        :yearSelectChange="yearSelectChange"
+        :getMonthsList="getMonthsList"
+        :formattedYearOrMonth="formattedYearOrMonth"
+        :numberOfYears="numberOfYears"
+        :startingYear="startingYear"
+      >
+        <div class="calendar__body" :style="calendarBodyStyle">
+          <!-- month -->
+          <slot name="calendar-month-header">
+            <div class="calendar__month" :style="calendarMonthStyle">
+              <slot name="calendar-month-prev-button" :prev="prev">
+                <button class="calendar__month__prev" @click="prev">
+                  <b>></b>
+                </button>
+              </slot>
 
-        <!-- week days -->
-        <div style="padding: 3px">
-          <div class="calendar__weeks">
-            <div
-              style="font-weight: bold"
-              class="calendar__weekday"
-              v-for="(weekday, w) in weekdays"
-              :key="w"
-            >
-              {{ weekday }}
+              <slot
+                name="calendar-month-select"
+                :monthValue="monthValue"
+                :monthSelectChange="monthSelectChange"
+                :getMonthsList="getMonthsList"
+                :formattedYearOrMonth="formattedYearOrMonth"
+                :formatNepali="formatNepali"
+              >
+                <slot
+                  v-if="!monthSelect"
+                  name="calendar-month-name-or-year"
+                  :formattedYearOrMonth="formattedYearOrMonth"
+                >
+                  <span>{{ formattedYearOrMonth }} </span>
+                </slot>
+                <select
+                  v-if="monthSelect"
+                  @change="monthSelectChange"
+                  v-model="monthValue"
+                  size="mini"
+                  :style="monthSelectStyle"
+                >
+                  <option
+                    style="text-align-last: center"
+                    v-for="(month, index) in getMonthsList"
+                    :key="month"
+                    :label="month"
+                    :value="index"
+                  />
+                </select>
+              </slot>
+
+              <slot
+                name="calendar-year-select"
+                :yearValue="yearValue"
+                :yearSelectChange="yearSelectChange"
+                :numberOfYears="numberOfYears"
+                :startingYear="startingYear"
+                :formatNepali="formatNepali"
+              >
+                <select
+                  @change="yearSelectChange"
+                  v-model="yearValue"
+                  size="mini"
+                  v-if="yearSelect"
+                  :style="yearSelectStyle"
+                >
+                  <option
+                    style="text-align-last: center"
+                    v-for="i in numberOfYears"
+                    :key="i"
+                    :value="startingYear + (i - 1)"
+                    :label="
+                      formatNepali
+                        ? getNepaliDateWithYear(startingYear + (i - 1)).substr(
+                            0,
+                            4
+                          )
+                        : startingYear + (i - 1)
+                    "
+                  ></option>
+                </select>
+              </slot>
+
+              <slot name="calendar-month-next-button" :next="next">
+                <button icon="el-icon-arrow-right" @click="next">
+                  <b>></b>
+                </button>
+              </slot>
             </div>
-          </div>
-          <!-- days of month -->
-          <div class="calendar__days">
-            <div
-              class="calendar__day_spacer"
-              :style="{ gridColumn: `span ${startWeek}` }"
-            ></div>
-            <div
-              :class="[
-                'calendar__day',
-                { selected: active(day) },
-                { today: checkToday(day) },
-              ]"
-              v-for="(day, d) in days"
-              :key="d"
-              @click="select(day)"
-            >
-              {{ formatNepali ? convertToNepali(day).substr(8, 10) : day.day }}
+          </slot>
+
+          <!-- week days -->
+          <slot name="calendar-week-days">
+            <div :style="calendarWeekWrapperStyle">
+              <div class="calendar__weeks" :style="calendarWeeksStyle">
+                <slot name="calendar-week-days-name" :weekdays="weekdays">
+                  <div
+                    :style="calendarWeekDaysStyle"
+                    class="calendar__weekday"
+                    v-for="(weekday, w) in weekdays"
+                    :key="w"
+                  >
+                    {{ weekday }}
+                  </div>
+                </slot>
+              </div>
+              <!-- days of month -->
+              <slot
+                name="calendar-days-grid"
+                :startWeek="startWeek"
+                :days="days"
+                :active="active"
+                :checkToday="checkToday"
+                :select="select"
+                :formatNepali="formatNepali"
+                :convertToNepali="convertToNepali"
+              >
+                <div class="calendar__days" :style="calendarDaysWrapperStyle">
+                  <div
+                    class="calendar__day_spacer"
+                    :style="{
+                      gridColumn: `span ${startWeek}`,
+                      ...calendarDaySpacerStyle,
+                    }"
+                  />
+                  <slot
+                    name="calendar-days"
+                    :days="days"
+                    :active="active"
+                    :checkToday="checkToday"
+                    :select="select"
+                    :formatNepali="formatNepali"
+                    :convertToNepali="convertToNepali"
+                  >
+                    <div
+                      :class="[
+                        'calendar__day',
+                        { selected: active(day) },
+                        { today: checkToday(day) },
+                      ]"
+                      :style="calendarDayStyle"
+                      v-for="(day, d) in days"
+                      :key="d"
+                      @click="select(day)"
+                    >
+                      {{
+                        formatNepali
+                          ? convertToNepali(day).substr(8, 10)
+                          : day.day
+                      }}
+                    </div>
+                  </slot>
+                </div>
+              </slot>
             </div>
-          </div>
+          </slot>
         </div>
-      </div>
-      <div class="calendar__footer">
-        <button @click="today">{{ formattedTodayText }}</button>
-      </div>
+      </slot>
+
+      <slot
+        name="calendar-footer"
+        :formattedTodayText="formattedTodayText"
+        :today="today"
+      >
+        <div class="calendar__footer" :style="calendarFooterStyle">
+          <button @click="today">{{ formattedTodayText }}</button>
+        </div>
+      </slot>
     </div>
   </div>
 </template>

--- a/src/components/NepaliDatePicker.vue
+++ b/src/components/NepaliDatePicker.vue
@@ -58,6 +58,35 @@ function select(dayData) {
 function today() {
   dateValue.value = getToday();
 }
+
+// Expose the composable state so parent components can access it via template ref
+defineExpose({
+  // Core state
+  formattedYear,
+  formattedDate,
+  formattedYearOrMonth,
+  formattedTodayText,
+
+  // Navigation
+  yearValue,
+  monthValue,
+  days,
+  weekdays,
+
+  // Methods
+  prev,
+  next,
+  show,
+  getToday,
+  selectDate,
+  select,
+  today,
+
+  // Utilities
+  formatNepali,
+  convertToNepali,
+  getNepaliDateWithYear,
+});
 </script>
 
 <template>

--- a/src/components/NepaliDatePicker.vue
+++ b/src/components/NepaliDatePicker.vue
@@ -1,5 +1,6 @@
 <script setup>
 // helpers
+import { getCurrentInstance, useSlots } from "vue";
 import useDate from "../composables/useDate";
 
 const props = defineProps({
@@ -17,6 +18,9 @@ const props = defineProps({
   monthSelect: { type: Boolean, default: true },
   classValue: { type: String, default: "" },
   placeholder: { type: String, default: "" },
+  calenderHeaderStyle: { type: Object, default: () => ({}) },
+  calenderYearStyle: { type: Object, default: () => ({}) },
+  calenderDateStyle: { type: Object, default: () => ({}) },
 });
 
 const dateValue = defineModel({ default: "" });
@@ -69,10 +73,20 @@ function today() {
       :class="classValue"
     />
     <div v-if="visible" :class="['calendar', { show: visible }]">
-      <div class="calendar__header">
-        <div class="calendar__year">{{ formattedYear }}</div>
-        <div class="calendar__date">{{ formattedDate }}</div>
-      </div>
+      <slot name="calender-header">
+        <div class="calendar__header" :style="calenderHeaderStyle">
+          <slot name="calendar-year" :formattedYear="formattedYear">
+            <div class="calendar__year" :style="calenderYearStyle">
+              {{ formattedYear }}
+            </div>
+          </slot>
+          <slot name="calendar-date" :formattedDate="formattedDate">
+            <div class="calendar__date" :style="calenderDateStyle">
+              {{ formattedDate }}
+            </div>
+          </slot>
+        </div>
+      </slot>
       <div class="calendar__body">
         <!-- month -->
         <div class="calendar__month">

--- a/src/examples/CustomDatePicker.vue
+++ b/src/examples/CustomDatePicker.vue
@@ -1,6 +1,6 @@
 <script type="module" setup>
 // node_modules
-import { defineProps, ref } from "vue";
+import { ref } from "vue";
 // helpers
 import useDate from "@/composables/useDate";
 


### PR DESCRIPTION
# PR Description

This update makes the NepaliDatePicker component fully extensible by introducing named + scoped slots and exposing the component’s internal state and methods.

# What’s Added

- Slots for header, body, year, month, date, and footer
	Developers can replace any UI section without touching core logic.

- Scoped slot props
	Slots now receive relevant data (e.g., formattedDate, year, navigation methods, selection handlers).

- Exposed component state via ref
	Consumers can access values like formattedYear, formattedDate, and functions such as goToNextMonth() or selectDate() directly from the parent.

# Why This Matters

The previous implementation locked the UI to a fixed structure, making customization difficult.
With this change, consumers can:

Override specific sections (header, date cell, footer, etc.)

Build an entirely custom UI using the exposed state

Combine scoped slots + direct ref access for full control

Style or theme the picker without modifying the library

# Example Usage
```vue
<script setup>
const slottedDatePickerRef = ref(null);
</script>


<NepaliDatePicker
  ref="slottedDatePickerRef"
  v-model="slottedDate"
  :calenderHeaderStyle="{ backgroundColor: '#b81c1d' }"
>
  <template #calendar-year>
    <div class="slotted-calender-year">
      Custom Year: {{ slottedDatePickerRef?.formattedYear }}
    </div>
  </template>

  <template #calendar-date="{ formattedDate }">
    <div class="slotted-calender-date">
      formattedDate: {{ formattedDate }}
    </div>
  </template>
</NepaliDatePicker>
	
```
# Result

The component is now flexible enough to support custom theming, design systems, or fully custom UIs, while keeping the core date-picker logic intact.